### PR TITLE
move systemd targets into defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,8 +12,10 @@ tusd_path: /usr/local/sbin/tusd
 #tusd_group: omit
 #tusd_mode: 0755
 
+# Systemd
 # If using Linux, you can install systemd service units to start and manage your tusd instances
 tusd_systemd: true
+tusd_systemd_target: "network.target time-sync.target"  # add here more targets as needed
 
 # Configuration for systemd-managed tusd instances - see the README for syntax
 tusd_instances: []
@@ -27,4 +29,3 @@ tusd_archive: "{{ (tusd_os == 'linux') | ternary('tar.gz', 'zip') }}"
 # You should generally not set this directly
 tusd_binary_platform: "tusd_{{ tusd_os }}_{{ tusd_arch }}"
 tusd_binary_archive_url: "https://github.com/tus/tusd/releases/download/{{ tusd_version }}/{{ tusd_binary_platform }}.{{ tusd_archive }}"
-

--- a/templates/tusd.service.j2
+++ b/templates/tusd.service.j2
@@ -4,8 +4,7 @@
 
 [Unit]
 Description=tusd server for {{ item.name }}
-After=network.target
-After=time-sync.target
+After={{ tusd_systemd_target }}
 
 [Service]
 UMask=022


### PR DESCRIPTION
I moved systemd target into the defaults file as I need to specify a few more targets to ensure remote fs are up before systemd try to start tus services.